### PR TITLE
companyLogo CSS property changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ function parseJobList(jobData) {
           .replaceAll(" ", "") || "";
       const jobUrl = job.find(".base-card__full-link").attr("href") || "";
       const companyLogo =
-        job.find(".artdeco-entity-image").attr("data-ghost-url") || "";
+        job.find(".artdeco-entity-image").attr("data-delayed-url") || "";
       const agoTime =
         job.find(".job-search-card__listdate").text().trim() || "";
       return {


### PR DESCRIPTION
Linkedin has updated the CSS  property for companyLogo. Current property returning the default logo for all the companies. I have updated it to correct logo.